### PR TITLE
Bump @nodary/utilities from 1.2.0 to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@api3/chains": "^3.5.1",
     "@api3/contracts": "^1.0.1",
-    "@nodary/utilities": "^1.2.0",
+    "@nodary/utilities": "^1.3.0",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.0",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
     "@nomicfoundation/hardhat-toolbox": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -540,10 +540,10 @@
   resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.7.1.tgz#b251c70f824ce3ca7f8dc3df08d58f005cc0507c"
   integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
 
-"@nodary/utilities@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@nodary/utilities/-/utilities-1.2.0.tgz#9376a01e5317b13055c4cc81063ef5f8ee76641a"
-  integrity sha512-raJ0QQ7LK6H3OrGi/wc18ZggvfUJbIP1BMYyRgVdwqwss0OBL9DqK4Vy+XPF4m56LwhDrXDyRkTEmcDIN1oHxQ==
+"@nodary/utilities@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@nodary/utilities/-/utilities-1.3.0.tgz#53f87d0a083ba77572ed4862b9bc70e90798a1b4"
+  integrity sha512-4fQ5KwA3ZL210vzFjGRymvy5vK6Q72ndpm2zi8l5h9CuSDJs+x7l1G7FSk0PJz40FpkscexDGUUZ65wPJyHRAg==
   dependencies:
     "@api3/airnode-abi" "^0.10.0"
     "@api3/chains" "^4.2.0"


### PR DESCRIPTION
Related to https://github.com/api3dao/tasks/issues/598 and https://github.com/api3dao/tasks/issues/605