### PR TITLE
Refine package matching for @api3/contracts-v9

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:recommended"],
   "packageRules": [
     {
-      "matchPackageNames": ["@api3/contracts-v9"],
+      "matchCurrentVersion": "npm:@api3/contracts@9.1.0",
       "enabled": false
     },
     {


### PR DESCRIPTION
Current solution depends on matching package names, it didn't work. I'm suggesting to try version matching. But not sure whether it works. 