### PR TITLE
Update renovate.json to ignore @api3/contracts@9.1.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,7 @@
       "minimumReleaseAge": null
     },
     {
-      "matchCurrentVersion": "npm:@api3/contracts@9.1.0",
+      "matchDepNames": ["@api3/contracts-v9"],
       "enabled": false
     }
   ],


### PR DESCRIPTION
The solution (https://github.com/api3dao/nodary-examples/pull/70) didn't work. Trying different way.