### PR TITLE
Enable Renovate automerge for non-major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>api3dao/renovate-config"],
+  "platformAutomerge": false,
+  "lockFileMaintenance": { "automerge": true },
   "major": {
     "dependencyDashboardApproval": true
   },
@@ -23,6 +25,12 @@
     {
       "matchDepNames": ["@api3/contracts-v9"],
       "enabled": false
+    },
+    {
+      "description": "Automerge non-major prod and dev dependency updates once CI passes",
+      "matchDepTypes": ["dependencies", "devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true
     }
   ],
   "reviewers": ["bdrhn9"]


### PR DESCRIPTION
Enable Renovate automerge so routine dependency bumps land without manual review.

- Automerge patch/minor `dependencies` and `devDependencies` once CI passes
- Automerge lock file maintenance PRs
- Keep `platformAutomerge` off so merges go through Renovate, not GitHub's native automerge

Major updates are unaffected, they still require dashboard approval.
